### PR TITLE
Implement pending tasks

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,6 @@ APP_ENV=prod
 PROJECT_NAME=shortcuts
 HTTP_PORT=5003
 
+# Default user ID used when running locally
+VITE_DEMO_USER_ID=1
+

--- a/README.md
+++ b/README.md
@@ -56,15 +56,21 @@
    Edit `.env.local` with:
    ```ini
    VITE_FIREBASE_API_KEY=...
-   VITE_FIREBASE_PROJECT_ID=...
-   VITE_FIREBASE_APP_ID=...
-   ```
+    VITE_FIREBASE_PROJECT_ID=...
+    VITE_FIREBASE_APP_ID=...
+    VITE_DEMO_USER_ID=1
+    ```
 
 4. Run in development mode:
    ```bash
-   npm run dev
-   ```
-   The application will be available at `http://localhost:5173`.
+    npm run dev
+    ```
+    The application will be available at `http://localhost:5173`.
+
+5. (Optional) Initialize Firestore with sample data:
+   1. Start the development server.
+   2. Open `http://localhost:5173/firebase-admin` in your browser.
+   3. Click **Initialize Firestore** to populate the database.
 
 ## Useful Scripts
 

--- a/TASK_PENDINGS.MD
+++ b/TASK_PENDINGS.MD
@@ -1,0 +1,6 @@
+# Tareas pendientes
+
+- ~~Permitir configurar el `userId` mediante variable de entorno, evitando el valor fijo que aparece en varios componentes.~~ ✅
+- ~~Añadir un script `npm test` e integrar pruebas unitarias con Jest y React Testing Library.~~ ✅
+- ~~Documentar el proceso para inicializar Firebase y las variables de entorno necesarias.~~ ✅
+- Dado que la aplicación se ejecutará en un servidor local para uso propio, no se prioriza convertirla en PWA ni añadir internacionalización por ahora.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+export default {
+  preset: 'ts-jest/presets/js-with-ts-esm',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
+  },
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "jest",
     "preview": "vite preview",
     "prepare": "husky install",
     "ci": "npm install --legacy-peer-deps"

--- a/src/__tests__/button.test.tsx
+++ b/src/__tests__/button.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import { Button } from '@/components/ui/button';
+
+describe('Button component', () => {
+  it('renders with text', () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByRole('button', { name: /click me/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/enhanced-shortcut-card.tsx
+++ b/src/components/enhanced-shortcut-card.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/lib/firebase';
 import { useToast } from '@/contexts/ToastContext';
 import type { Shortcut, UserNote } from '@/lib/types';
+import { demoUserId } from '@/lib/env';
 
 interface EnhancedShortcutCardProps {
   shortcut: Shortcut;
@@ -65,7 +66,7 @@ export default function EnhancedShortcutCard({
   const { toggleFavorite, isFavorite } = useFavorites();
   const { toast } = useToast();
   const favorite = isFavorite(shortcut.id);
-  const userId = 1; // Using demo user
+  const userId = demoUserId;
   const [userNote, setUserNote] = useState<UserNote | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 

--- a/src/contexts/FavoritesContext.tsx
+++ b/src/contexts/FavoritesContext.tsx
@@ -12,7 +12,9 @@ const FavoritesContext = createContext<FavoritesContextType | undefined>(
   undefined,
 );
 
-const CURRENT_USER_ID = 1;
+import { demoUserId } from '@/lib/env';
+
+const CURRENT_USER_ID = demoUserId;
 
 export function FavoritesProvider({ children }: { children: React.ReactNode }) {
   const [favorites, setFavorites] = useState<string[]>([]);

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -5,3 +5,5 @@ export const firebaseConfig = {
   storageBucket: `${import.meta.env.VITE_FIREBASE_PROJECT_ID}.appspot.com`,
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
 };
+
+export const demoUserId = Number(import.meta.env.VITE_DEMO_USER_ID) || 1;

--- a/src/pages/Quiz.tsx
+++ b/src/pages/Quiz.tsx
@@ -27,6 +27,7 @@ import {
 import { useToast } from '@/contexts/ToastContext';
 import { Link } from 'wouter';
 import type { QuizSession, Shortcut } from '@/lib/types';
+import { demoUserId } from '@/lib/env';
 
 interface QuizQuestion {
   shortcut: Shortcut;
@@ -46,7 +47,7 @@ export default function QuizPage() {
   const [timeLeft, setTimeLeft] = useState(300);
   const [timerActive, setTimerActive] = useState(false);
   const { toast } = useToast();
-  const userId = 1;
+  const userId = demoUserId;
   const [shortcuts, setShortcuts] = useState<Shortcut[]>([]);
   const [quizHistory, setQuizHistory] = useState<QuizSession[]>([]);
   useEffect(() => {


### PR DESCRIPTION
## Summary
- make `demoUserId` configurable
- replace hard-coded user ids
- add Jest config and a sample test
- document Firebase setup and env vars
- mark pending tasks as done

## Testing
- `npm run lint` *(fails: 11 errors, 10 warnings)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851a073294883279234a8a21163b209